### PR TITLE
fix(ui): gate route reinforce() behind RuVector flag + refresh README perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,16 @@ The compiler is built to run on every keystroke. Native `--release` latency
 | `count_tokens` (medium) | ~230 ns | ~4.3 M/s |
 | `analyze` (medium) | ~36 µs | ~28 K/s |
 | `compress` (medium) | ~50 µs | ~20 K/s |
-| `optimize` (medium) | ~397 µs | ~2.5 K/s |
-| `optimize` (large, ~2K tok) | ~5.7 ms | ~174/s |
+| `optimize` (medium) | ~485 µs | ~2.1 K/s |
+| `optimize` (large, ~2K tok) | ~2.5 ms | ~400/s |
 
-The `compress`/`optimize` paths were tuned to lowercase each line once per pass
-instead of once per filler phrase — a **5.4× `compress`** and **2.1×
-`optimize(large)`** speedup. The UI debounces `analyze()` to ~120 ms, leaving
-ample headroom.
+Two tuning passes landed here. First, `compress` was changed to lowercase each
+line **once per pass** instead of once per filler phrase (**5.4×** `compress`).
+Second, `optimize_internal` now analyzes each distinct text **exactly once**
+instead of re-analyzing `raw` and re-parsing the compressed text
+(**1.9×** `optimize(large)`). Both keep output byte-identical. The committed
+`src/wasm/pkg` is rebuilt so the browser app gets these gains; the UI debounces
+`analyze()` to ~120 ms, leaving ample headroom.
 
 ### Live benchmark against OpenRouter `fusion`
 

--- a/src/pages/Optimizer.tsx
+++ b/src/pages/Optimizer.tsx
@@ -222,7 +222,10 @@ const Optimizer = () => {
       });
       setPriors(recall(raw));
       // Reinforce the chosen route so the router learns this prompt→tier mapping.
-      if (r.accepted && routeHint) {
+      // Gated by the RuVector flag: without it, reinforce() would still spin up
+      // the router wasm on every accepted compile (and log a load error when the
+      // optional package isn't served), for a feature the user hasn't enabled.
+      if (r.accepted && routeHint && ruvectorActive()) {
         void reinforce(raw, routeHint.tier, routeHint.examples);
       }
       toast({


### PR DESCRIPTION
Found by browser-testing the `/optimize` page (agent-browser).

## Bug
`handleOptimize` called `reinforce()` on **every accepted compile regardless of the RuVector feature flag**. With the flag off (the default), that eagerly loaded the optional `@ruvector/ruvllm-wasm` router and logged a `RuVector router unavailable` CompileError on every compile (the package's wasm isn't served in dev). `refineRoute` was already gated; `reinforce` was not.

## Fix
Gate `reinforce()` with `ruvectorActive()`, matching `refineRoute`.

**Verified in-browser** by delta: with the fix, the warning count stays flat across repeated compiles (no load attempt). Also confirmed live that the compiler, 7-objective scoring, firewall (`ALLOW · risk 0.02`), prompt-memory recording (`1 recorded` — the H1 fix), and the `HMAC-SHA-256 witness · integrity checksum` receipt wording (the C1 fix) all render correctly on the rebuilt wasm.

## README
Refreshed the perf table to post-optimization figures (`optimize(medium)` ~485 µs, `optimize(large)` ~2.5 ms) and documented the analyze-once optimization alongside the compress one.

## Known follow-up (tracked in #3)
When RuVector is toggled **on**, its wasm still 404s in dev (served as `index.html`) — a Vite asset-serving/packaging gap for the optional package. It degrades gracefully (router unavailable → static hint), so it's a separate experimental-feature task, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)